### PR TITLE
adding trailing newline character to outbound client traffic

### DIFF
--- a/lib/main.rb
+++ b/lib/main.rb
@@ -187,7 +187,7 @@ class MainGame
 			game_end = true if game_state == :resign || game_state == :save
 
 			send = game_state.to_s + ":"
-			send << board_serialization
+			send << board_serialization << "\n"
 			net.puts send
 			game_end
 		end


### PR DESCRIPTION
Need the trailing newline for interoperability between ruby_chess and PTCE.
